### PR TITLE
Add MoodMapper project

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Sistema modular de narrativa com memória emocional, consequências e lógica pr
 ### 🌍 UltraWorld (privado)
 Simulador completo de civilizações emergentes com IA viva, clima emocional, religiões dinâmicas e criação divina.
 
+### 🙂 MoodMapper
+Ferramenta para visualizar e acompanhar estados emocionais.
+
 ### 🛠️ Outros Projetos
 - Sistema de construção procedural para jogos (em Unity)
 - Engine de moralidade e leis emergentes
@@ -40,6 +43,7 @@ public class Agent : MonoBehaviour
 ```
 Mais exemplos podem ser encontrados na pasta [samples](samples/) do repositório.
 Alguns trechos técnicos do UltraWorld estão disponíveis em [ultraworld](ultraworld/).
+Um rastreador de humor simples está em [moodmapper](moodmapper/).
 
 ---
 
@@ -65,6 +69,9 @@ A modular narrative system with emotional memory, consequences and procedural lo
 
 ### 🌍 UltraWorld (private)
 A complete simulator of emerging civilizations with living AI, emotional climate, dynamic religions and divine creation.
+
+### 🙂 MoodMapper
+Tool to visualize and track emotional states.
 
 ### 🛠️ Other Projects
 - Procedural building system for games (Unity)
@@ -92,6 +99,7 @@ public class Agent : MonoBehaviour
 ```
 More examples can be found in the [samples](samples/) folder.
 Additional technical snippets from UltraWorld are in the [ultraworld](ultraworld/) directory.
+A simple mood tracking tool is in the [moodmapper](moodmapper/) directory.
 
 ---
 

--- a/moodmapper/moodmapper.py
+++ b/moodmapper/moodmapper.py
@@ -1,0 +1,30 @@
+"""Simple mood mapping tool."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+
+@dataclass
+class MoodEntry:
+    mood: str
+    timestamp: datetime = datetime.now()
+
+class MoodTracker:
+    def __init__(self):
+        self.entries: List[MoodEntry] = []
+
+    def log_mood(self, mood: str):
+        self.entries.append(MoodEntry(mood=mood, timestamp=datetime.now()))
+
+    def summary(self):
+        counts = {}
+        for entry in self.entries:
+            counts[entry.mood] = counts.get(entry.mood, 0) + 1
+        return counts
+
+if __name__ == "__main__":
+    tracker = MoodTracker()
+    tracker.log_mood("happy")
+    tracker.log_mood("sad")
+    tracker.log_mood("happy")
+    print("Mood counts:", tracker.summary())


### PR DESCRIPTION
## Summary
- showcase MoodMapper in Portuguese and English sections
- mention MoodMapper folder alongside other directories
- add simple `moodmapper` example script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68481545aacc83239805d7b1c92d945c